### PR TITLE
Minor adjustments + retention

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Archive artifact
       shell: bash
-      run: -|
+      run: |
         tar \
           --dereference --hard-dereference \
           --directory ${{ inputs.path }} \

--- a/action.yml
+++ b/action.yml
@@ -1,18 +1,29 @@
 name: 'Upload Pages artifact'
 description: 'A composite action that prepares your static assets to be deployed to GitHub Pages'
 inputs:
-  directory:
-    description: 'The directory in your workspace that contains the built assets'
+  path:
+    description: 'Path of the directoring containing the static assets.'
     required: true
     default: '_site/'
+  retention-days:
+    description: 'Duration after which artifact will expire in days.'
+    required: false
+    default: '1'
 runs:
-  using: "composite"
-  steps:      
-    - name: Archive build output
-      run: "tar --dereference --hard-dereference --directory ${{ inputs.directory }} -cvf artifact.tar ."
+  using: composite
+  steps:
+    - name: Archive artifact
       shell: bash
+      run: -|
+        tar \
+          --dereference --hard-dereference \
+          --directory ${{ inputs.path }} \
+          -cvf ${{ runner.temp }}/artifact.tar \
+          --exclude=.git \
+          .
     - name: Upload artifact
       uses: actions/upload-artifact@main
       with:
-        name: "github-pages"
-        path: artifact.tar
+        name: github-pages
+        path: ${{ runner.temp }}/artifact.tar
+        retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
As part of https://github.com/github/pages-engineering/issues/1197.

Few adjustments:

- `directory` -> `path` (since `path` is more commonly used for other first-party actions)
- drop mention of "built" assets (assets may not necessarily be built and could just live in a repo)
- move the `artifact.tar` file in a temp folder so it does not clobber the potential source
- add `.git` to exclusion list (that sounds general enough we can include it in all cases, not just for [`.nojekyll`](https://github.com/github/github/blob/57ab41c7e317991b3967614050b19eb7fdcb1b1c/packages/artifacts/app/models/page/template/page_build_action.yaml.erb#L27))
- add an input to control retention-days on the artifact (default to 1 day)