### PR TITLE
Exclude the `.github` directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ runs:
           --directory ${{ inputs.path }} \
           -cvf ${{ runner.temp }}/artifact.tar \
           --exclude=.git \
+          --exclude=.github \
           .
     - name: Upload artifact
       uses: actions/upload-artifact@main


### PR DESCRIPTION
Currently, our starter workflow for static sites will include the `.github/workflows/*` files in the uploaded artifact. This is not a blocker, but it is also not ideal. 🤔 

We _could_ exclude the `.github` directory from the `tar` command by default as well. 🤷🏻‍♂️ 

h/t @yoannchaudet 